### PR TITLE
feat: add selector for useAyamami hook

### DIFF
--- a/demo/index.tsx
+++ b/demo/index.tsx
@@ -8,6 +8,7 @@ import { Ayanami, Effect, EffectAction, Reducer, useAyanami } from '../src'
 
 interface State {
   count: number
+  input: string
 }
 
 interface TipsState {
@@ -30,6 +31,7 @@ class Tips extends Ayanami<TipsState> {
 class Count extends Ayanami<State> {
   defaultState = {
     count: 0,
+    input: '',
   }
 
   otherProps = ''
@@ -40,17 +42,22 @@ class Count extends Ayanami<State> {
 
   @Reducer()
   add(state: State, count: number): State {
-    return { count: state.count + count }
+    return { ...state, count: state.count + count }
   }
 
   @Reducer()
   addOne(state: State): State {
-    return { count: state.count + 1 }
+    return { ...state, count: state.count + 1 }
   }
 
   @Reducer()
   reset(): State {
-    return { count: 0 }
+    return { count: 0, input: '' }
+  }
+
+  @Reducer()
+  changeInput(state: State, value: string): State {
+    return { ...state, input: value }
   }
 
   @Effect()
@@ -67,7 +74,7 @@ class Count extends Ayanami<State> {
 }
 
 function CountComponent() {
-  const [{ count }, actions] = useAyanami(Count)
+  const [{ count, input }, actions] = useAyanami(Count)
   const [{ tips }] = useAyanami(Tips)
 
   const add = (count: number) => () => actions.add(count)
@@ -76,12 +83,26 @@ function CountComponent() {
   return (
     <div>
       <p>count: {count}</p>
+      <p>input: {input}</p>
       <p>tips: {tips}</p>
       <button onClick={add(1)}>add one</button>
       <button onClick={minus(1)}>minus one</button>
-      <button onClick={actions.reset}>reset to zero</button>
+      <button onClick={actions.reset}>reset</button>
+      <InputComponent />
     </div>
   )
 }
+
+const InputComponent = React.memo(() => {
+  const [input, actions] = useAyanami(Count, { selector: (state) => state.input })
+
+  return (
+    <div>
+      <h3>{input}</h3>
+      <input value={input} onChange={(e) => actions.changeInput(e.target.value)} />
+    </div>
+  )
+})
+InputComponent.displayName = 'InputComponent'
 
 ReactDOM.render(<CountComponent />, document.querySelector('#app'))

--- a/src/hooks/shallow-equal.ts
+++ b/src/hooks/shallow-equal.ts
@@ -1,0 +1,10 @@
+export const shallowEqual = (a: any, b: any): boolean => {
+  if (a === b) return true
+  if (typeof a === 'object' && typeof b === 'object' && a !== null && b !== null) {
+    return (
+      Object.keys(a).length === Object.keys(b).length &&
+      Object.keys(a).every((key) => a[key] === b[key])
+    )
+  }
+  return false
+}

--- a/src/hooks/use-ayanami-instance.ts
+++ b/src/hooks/use-ayanami-instance.ts
@@ -4,25 +4,19 @@ import get from 'lodash/get'
 import { ActionMethodOfAyanami, Ayanami, combineWithIkari } from '../core'
 import { useSubscribeAyanamiState } from './use-subscribe-ayanami-state'
 
-export interface UseAyanamiInstanceConfig {
+export interface UseAyanamiInstanceConfig<S, U> {
   destroyWhenUnmount?: boolean
+  selector?: (state: S) => U
 }
 
-export type UseAyanamiInstanceResult<M extends Ayanami<S>, S> = [
-  Readonly<S>,
-  ActionMethodOfAyanami<M, S>,
-]
+export type UseAyanamiInstanceResult<M extends Ayanami<S>, S, U> = [U, ActionMethodOfAyanami<M, S>]
 
-type Config = UseAyanamiInstanceConfig
-
-type Result<M extends Ayanami<S>, S> = UseAyanamiInstanceResult<M, S>
-
-export function useAyanamiInstance<M extends Ayanami<S>, S>(
+export function useAyanamiInstance<M extends Ayanami<S>, S, U>(
   ayanami: M,
-  config?: Config,
-): Result<M, S> {
+  config?: UseAyanamiInstanceConfig<S, U>,
+): UseAyanamiInstanceResult<M, S, U> {
   const ikari = React.useMemo(() => combineWithIkari(ayanami), [ayanami])
-  const state = useSubscribeAyanamiState(ayanami)
+  const state = useSubscribeAyanamiState(ayanami, config ? config.selector : undefined)
 
   React.useEffect(
     () => () => {
@@ -35,5 +29,5 @@ export function useAyanamiInstance<M extends Ayanami<S>, S>(
     [ayanami, config],
   )
 
-  return [state, ikari.triggerActions] as Result<M, S>
+  return [state, ikari.triggerActions] as UseAyanamiInstanceResult<M, S, U>
 }


### PR DESCRIPTION
- [x] New Feature
- [x] Test Case

When I use ayanami in our business, I do encounter some performance bottlenecks due to existing **"subscribe - setState- re-render loop"**, especially for very large modules.

So I added a simple state selector implementation for ayanami to give us some methods for performance optimization.

_("Selector Deps" is not added, because I think they are not commonly used and may increase the learning burden. So all selectors are lazy called when state updated)_

PS: I see a similar implementation in the “1.0 branch”, but not quite sure why it was deprecated? 👀

