### PR TITLE
fix(hooks): useAyanami type define

### DIFF
--- a/src/hooks/use-ayanami-instance.ts
+++ b/src/hooks/use-ayanami-instance.ts
@@ -4,7 +4,7 @@ import get from 'lodash/get'
 import { ActionMethodOfAyanami, Ayanami, combineWithIkari } from '../core'
 import { useSubscribeAyanamiState } from './use-subscribe-ayanami-state'
 
-export interface UseAyanamiInstanceConfig<S, U> {
+export interface UseAyanamiInstanceConfig<S = unknown, U = unknown> {
   destroyWhenUnmount?: boolean
   selector?: (state: S) => U
 }

--- a/test/specs/hooks.spec.tsx
+++ b/test/specs/hooks.spec.tsx
@@ -111,9 +111,9 @@ describe('Hooks spec:', () => {
       })
 
       const OuterComponent = () => {
-        const [state, actions] = useAyanami(Count, { scope: TransientScope })
+        const [{ count }, actions] = useAyanami(Count, { scope: TransientScope })
         const addOne = useCallback(() => actions.add(1), [])
-        outerRenderSpy(state.count)
+        outerRenderSpy(count)
         return (
           <div>
             <button onClick={addOne}>add one</button>


### PR DESCRIPTION
Fixed the problem that __the state type was not inferred correctly__ when selector was not declared.