### PR TITLE
perf: avoid using selector each render

### DIFF
--- a/src/hooks/shallow-equal.ts
+++ b/src/hooks/shallow-equal.ts
@@ -1,10 +1,9 @@
 export const shallowEqual = (a: any, b: any): boolean => {
   if (a === b) return true
   if (typeof a === 'object' && typeof b === 'object' && a !== null && b !== null) {
-    return (
-      Object.keys(a).length === Object.keys(b).length &&
-      Object.keys(a).every((key) => a[key] === b[key])
-    )
+    const keys = Object.keys(a)
+    if (keys.length !== Object.keys(b).length) return false
+    return keys.every((key) => key in b && a[key] === b[key])
   }
   return false
 }

--- a/src/hooks/use-ayanami.ts
+++ b/src/hooks/use-ayanami.ts
@@ -23,7 +23,7 @@ interface Config<S, U> extends Partial<ScopeConfig> {
   selector?: (state: S) => U
 }
 
-export function useAyanami<M extends Ayanami<any>, U = M extends Ayanami<infer S> ? S : never>(
+export function useAyanami<M extends Ayanami<S>, S, U = M extends Ayanami<infer SS> ? SS : never>(
   A: ConstructorOf<M>,
   config?: M extends Ayanami<infer S> ? Config<S, U> : never,
 ): M extends Ayanami<infer S>
@@ -38,7 +38,7 @@ export function useAyanami<M extends Ayanami<any>, U = M extends Ayanami<infer S
   const ayanami = React.useMemo(() => getInstanceWithScope(A, reqScope), [reqScope])
   ayanami.scopeName = scope || DEFAULT_SCOPE_NAME
 
-  const useAyanamiInstanceConfig = React.useMemo<UseAyanamiInstanceConfig>(() => {
+  const useAyanamiInstanceConfig = React.useMemo<UseAyanamiInstanceConfig<S>>(() => {
     return { destroyWhenUnmount: scope === TransientScope, selector }
   }, [reqScope])
 


### PR DESCRIPTION
1. **Perf:** Avoid using selector each render to improve performance
2. **Chore:** Restored the past generic format to ensure backward compatibility
3. **Fix:** Fix a small bug in shallowEqual when two objects are in different schema.